### PR TITLE
feat(ko-version-file): support version file input

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,34 @@ jobs:
             echo "${KO_DOCKER_REPO} != already-set"
             exit 1
           fi
+
+      - name: Install ko-version-file
+        run: echo "v0.6.0" > .ko-version
+
+      - name: Install ko-version-file
+        uses: ./
+        with:
+          ko-version-file: .ko-version
+
+      - name: Check installed version
+        run: ko version | grep 0.6.0
+
+      - name: Install version if ko-version-file is set but version is explicit
+        uses: ./
+        with:
+          ko-version-file: .ko-version
+          version: v0.8.0
+
+      - name: Check installed version
+        run: ko version | grep 0.8.0
+
+      - name: Fail if ko-version-file is set but it's not a valid file
+        continue-on-error: true
+        id: validation
+        uses: ./
+        with:
+          ko-version-file: .unknown-file
+
+      - name: Verify step failed if ko-version-file is set but it's not a valid file
+        if: steps.validation.outcome != 'failure'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you'd like support for Windows runners, [let us know](https://github.com/ko-b
 
 ### Select `ko` version to install
 
+#### `version` input
+
 By default, `ko-build/setup-ko` installs the [latest released version of `ko`](https://github.com/ko-build/ko/releases).
 
 You can select a version with the `version` parameter:
@@ -51,6 +53,18 @@ You can select a version with the `version` parameter:
 ```
 
 To build and install `ko` from source using `go install`, specify `version: tip`.
+
+#### `ko-version-file` input
+
+If the `ko-version-file` input is specified, the action will extract the version from the file and install it.
+
+If both `version` and `ko-version-file` inputs are provided, the `version` input will be used.
+
+```yaml
+- uses: ko-build/setup-ko@v0.10
+  with:
+    ko-version-file: '.ko-version'
+```
 
 ### Pushing to other registries
 

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,12 @@ branding:
 inputs:
   version:
     description: 'Version of ko to install (tip, latest-release, v0.14.1, etc.)'
-    required: true
+    required: false
     default: 'latest-release'
+  ko-version-file:
+    description: 'Path to a file containing the Go version to install (if different from default)'
+    required: false
+    default: ''
   use-sudo:
     description: 'set to true if install-dir location requires sudo privs'
     required: false
@@ -16,19 +20,33 @@ runs:
   using: "composite"
   steps:
   - shell: bash
+    env:
+      KO_VERSION_FILE: ${{ inputs.ko-version-file }}
+      KO_VERSION: ${{ inputs.version }}
+      USE_SUDO: ${{ inputs.use-sudo }}
     run: |
       set -ex
 
       SUDO=
-      if [[ "${{ inputs.use-sudo }}" == "true" ]] && command -v sudo >/dev/null; then
+      if [[ "${USE_SUDO}" == "true" ]] && command -v sudo >/dev/null; then
         SUDO=sudo
+      fi
+
+      # If KO_VERSION_FILE is set and KO_VERSION is default, read version from file
+      KO_VERSION_TO_INSTALL=${KO_VERSION}
+      if [[ -n "${KO_VERSION_FILE}" && "${KO_VERSION}" == "latest-release" ]]; then
+        if [[ ! -f "${KO_VERSION_FILE}" ]]; then
+          echo "KO_VERSION_FILE ${KO_VERSION_FILE} does not exist"
+          exit 1
+        fi
+        KO_VERSION_TO_INSTALL=$(cat "${KO_VERSION_FILE}" | tr -d '[:space:]')
       fi
 
       # Install ko:
       # - if version is "tip", install from tip of main.
       # - if version is "latest-release", look up latest release.
       # - otherwise, install the specified version.
-      case ${{ inputs.version }} in
+      case ${KO_VERSION_TO_INSTALL} in
       tip)
         echo "Installing ko using go install"
         go install github.com/google/ko@main
@@ -37,7 +55,7 @@ runs:
         tag=$(curl -L -s -u "username:${{ github.token }}" https://api.github.com/repos/ko-build/ko/releases/latest | jq -r '.tag_name')
         ;;
       *)
-        tag="${{ inputs.version }}"
+        tag="${KO_VERSION_TO_INSTALL}"
       esac
 
       os=${{ runner.os }}


### PR DESCRIPTION
### What

* Support `ko-version-file` input.
* if `version` and `ko-version-file` inputs are set and `version` is not `latest-release` then `version` is honoured, otherwise `ko-version-file`.
* Add e2e tests to the `ci.yml` workflow.
* Use [intermediate env variables](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable) to avoid shell injection 

### Why

This is a common pattern in some other projects:
- https://github.com/actions/setup-java#usage
- https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file
- https://github.com/actions/setup-node/#usage
- https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-file-input

